### PR TITLE
fixed test for qa_pa_sink

### DIFF
--- a/python/qa_pa_sink.py
+++ b/python/qa_pa_sink.py
@@ -36,6 +36,7 @@ class qa_pa_sink (gr_unittest.TestCase):
             samp_rate=96000,
             nchannels=2,
             application_name='GNU Radio test',
+            device=None,
             stream_name='test',
             channel_map=None)
         self.tb.connect((left_src, 0), (sink, 0))


### PR DESCRIPTION
Even though it made test not technically fail, it simply plays a tone endlessly, and can only be forcefully interrupted.
