### PR TITLE
added throttle flags to PA blocks

### DIFF
--- a/grc/pulseaudio_pa_sink.xml
+++ b/grc/pulseaudio_pa_sink.xml
@@ -3,6 +3,7 @@
   <name>PulseAudio Sink</name>
   <key>pulseaudio_pa_sink</key>
   <category>Sinks</category>
+  <flags>throttle</flags>
   <import>import pulseaudio</import>
   <make>pulseaudio.pa_sink(
         samp_rate=$samp_rate,

--- a/grc/pulseaudio_pa_source.xml
+++ b/grc/pulseaudio_pa_source.xml
@@ -3,6 +3,7 @@
   <name>PulseAudio Source</name>
   <key>pulseaudio_pa_source</key>
   <category>Sources</category>
+  <flags>throttle</flags>
   <import>import pulseaudio</import>
   <make>pulseaudio.pa_source(
         samp_rate=$samp_rate,


### PR DESCRIPTION
If I understand GNU Radio correctly, it's just an indicator that that the block blocks (hehe), and will not consume 100% CPU if given the chance.

GNU Radio checks the flow graph, and if there're no "throttle" blocks, issues a warning.
