### PR TITLE
hack: add pulse-simple to target_link_libraries just like this #2

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -38,7 +38,8 @@ if(NOT pulseaudio_sources)
 endif(NOT pulseaudio_sources)
 
 add_library(gnuradio-pulseaudio SHARED ${pulseaudio_sources})
-target_link_libraries(gnuradio-pulseaudio ${Boost_LIBRARIES} ${GNURADIO_ALL_LIBRARIES})
+target_link_libraries(gnuradio-pulseaudio ${Boost_LIBRARIES}
+    ${GNURADIO_ALL_LIBRARIES} pulse-simple)
 set_target_properties(gnuradio-pulseaudio PROPERTIES DEFINE_SYMBOL "gnuradio_pulseaudio_EXPORTS")
 
 if(APPLE)
@@ -75,6 +76,7 @@ target_link_libraries(
   ${GNURADIO_RUNTIME_LIBRARIES}
   ${Boost_LIBRARIES}
   ${CPPUNIT_LIBRARIES}
+  pulse-simple
   gnuradio-pulseaudio
 )
 


### PR DESCRIPTION
There should be a better way, but this way it'll at least build and work.
